### PR TITLE
Key maps and snippets

### DIFF
--- a/Keymaps/Default.sublime-keymap
+++ b/Keymaps/Default.sublime-keymap
@@ -1840,5 +1840,109 @@
         "match_all": true
       }
     ]
+  },
+  {
+    "keys": [
+      "ctrl+b"
+    ],
+    "command": "insert_snippet",
+    "args": {
+      "contents": "*${0:$SELECTION}*"
+    },
+    "context": [
+      {
+        "key": "selection_empty",
+        "operator": "equal",
+        "operand": false,
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "text.asciidoc",
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "not_equal",
+        "operand": "markup.raw",
+        "match_all": true
+      }
+    ]
+  },
+  {
+    "keys": [
+      "ctrl+i"
+    ],
+    "command": "insert_snippet",
+    "args": {
+      "contents": "_${0:$SELECTION}_"
+    },
+    "context": [
+      {
+        "key": "selection_empty",
+        "operator": "equal",
+        "operand": false,
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "text.asciidoc",
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "not_equal",
+        "operand": "markup.raw",
+        "match_all": true
+      }
+    ]
+  },
+  {
+    "keys": [
+      "ctrl+shift+'"
+    ],
+    "command": "insert_snippet",
+    "args": {
+      "contents": "\"`${0:$SELECTION}`\""
+    },
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "text.asciidoc",
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "not_equal",
+        "operand": "markup.raw",
+        "match_all": true
+      }
+    ]
+  },
+  {
+    "keys": [
+      "ctrl+'"
+    ],
+    "command": "insert_snippet",
+    "args": {
+      "contents": "'`${0:$SELECTION}`'"
+    },
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "text.asciidoc",
+        "match_all": true
+      },
+      {
+        "key": "selector",
+        "operator": "not_equal",
+        "operand": "markup.raw",
+        "match_all": true
+      }
+    ]
   }
 ]

--- a/Keymaps/Default.sublime-keymap.py
+++ b/Keymaps/Default.sublime-keymap.py
@@ -183,10 +183,25 @@ Keymap(
         .also('preceding_text').regex_match('^\\s*(?:[*.-]+|<\\d+>)\\s+$')
         .also('following_text').regex_match('^\\s*$'),
 
+    bind('ctrl+b')
+        .to('insert_snippet', contents='*${0:$SELECTION}*')
+        .when('selection_empty').false(),
+
+    bind('ctrl+i')
+        .to('insert_snippet', contents='_${0:$SELECTION}_')
+        .when('selection_empty').false(),
+
+    bind("ctrl+shift+'")
+        .to('insert_snippet', contents="\"`${0:$SELECTION}`\""),
+
+    bind("ctrl+'")
+        .to('insert_snippet', contents="'`${0:$SELECTION}`'"),
+        
     common_context=[
         context('selector').equal('text.asciidoc'),
         context('selector').not_equal('markup.raw')
     ],
     default_match_all=True
+
 
 ).dump()  # nopep8

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ For the above reasons, it's possible that during the Alpha stage various syntax 
 
 ## Keymaps
 
+* Ctrl-B surrounds the selected text with asterisks (for bold/strong). Hit it once for constrained. Hit it again for unconstrained. Note: If no text is selected, then Ctrl-B will invoke the build system.
+* Ctrl-I surrounds the selected text with underscores (for italics/emphasis). Hit it once for constrained. Hit it again for unconstrained.
+* Ctrl-" surrounds the selected text (or just the cursor) with typographical double quotes. 
+* Ctrl-' surrounds the selected text (or just the cursor) with typographical single quotes. 
 * Asterisks (strong), underscores (emphasis), backticks (monospaced), English quotation marks, and Czech quotation marks are autopaired and will wrap selected text.
     - If you start an empty pair and hit backspace, both elements are deleted.
     - If you start an empty asterisks pair and hit <kbd>Space</kbd> or <kbd>Tab</kbd>, the right element is deleted (because you probably wanted to start a list, not a strong text).
@@ -104,12 +108,35 @@ For the above reasons, it's possible that during the Alpha stage various syntax 
 | Keyboard Shortcut  | `kbd` <kbd>Tab</kbd>                      |
 | Listing Block      | `--` <kbd>Tab</kbd>                       |
 | Passthrough Block  |                                           |
-| Quote Block        | `__` <kbd>Tab</kbd>                       |
+| Quote Block        | `__` <kbd>Tab</kbd> or `""` <kbd>Tab</kbd> |
 | Section Title 1–5  | `h1` <kbd>Tab</kbd> … `h5` <kbd>Tab</kbd> |
 | Sidebar block      |                                           |
 | Table              | `= `<kbd>Tab</kbd>                        |
+| Anchored Subsection| `[[` <kbd>Tab</kbd>                       |
+| Anchor Reference   | `<<` <kbd>Tab</kbd>                       |
 
 
+### Keyboard Shortcut and Button 
+
+In-line macros that render keycaps and button presses, respectively.
+
+### Anchored Subsection and Anchor Reference 
+
+These snippets ensure that your anchor names properly conform (lower-case, no spaces).
+
+Type this: `[[` <kbd>Tab</kbd> Navigable Text
+
+And you get this:
+```
+    [[navigable-text]]
+    === Navigable Text
+```
+Type this: `<<` <kbd>Tab</kbd> Navigable Text
+
+And you get this:
+```
+    <<navigable-text,Navigable Text>>
+```
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You should therefore install it manually, via Git:
     * Windows: `%APPDATA%\Sublime Text 3\Packages\`
 2. From that directory, invoke Git to clone this repository into the `Asciidoctor` subdirectory:
 
-        git clone https://github.com/tajmone/ST3-Asciidoctor.git Asciidoctor
+        git clone https://github.com/aireilly/ST3-Asciidoctor.git Asciidoctor
 
 3. Restart SublimeText.
 

--- a/Snippets/Anchor-Reference.sublime-snippet
+++ b/Snippets/Anchor-Reference.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+   <description>Anchor Reference</description>
+   <content><![CDATA[<<${1/( )|([A-Z])|([^-0-9a-z])/(?1-:)(?2\l$2:)(?3:)/g},${1:term}>>]]></content>
+   <tabTrigger>&lt;&lt;</tabTrigger>
+   <scope>text.asciidoc</scope>
+</snippet>

--- a/Snippets/Anchored-Subsection.sublime-snippet
+++ b/Snippets/Anchored-Subsection.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+   <description>Anchored Subsection</description>
+   <content><![CDATA[[[${1/( )|([A-Z])|([^-0-9a-z])/(?1-:)(?2\l$2:)(?3:)/g}]]
+=== ${1:term}
+
+$0]]></content>
+   <tabTrigger>[[</tabTrigger>
+   <scope>text.asciidoc</scope>
+</snippet>

--- a/Snippets/Quote-Block-2.sublime-snippet
+++ b/Snippets/Quote-Block-2.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+  <description>Quote Block</description>
+  <content><![CDATA[
+
+[quote, ${1:Attribution}, ${2:Cite Title}]
+____________________________________________________________________________
+$3
+____________________________________________________________________________
+
+$0]]></content>
+  <tabTrigger>""</tabTrigger>
+  <scope>text.asciidoc</scope>
+</snippet>

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -570,13 +570,13 @@ contexts:
 #-----------------------------------------------------------------------------#
 
   characters:
-  #   - include: attribute_reference
+    - include: attribute_reference
+    - include: macro
   #   - include: entity_number
   #   - include: entity_name
   #   - include: escape
   #   - include: replacement
   #   - include: macro_pass
-    - include: macro
   #   - include: xref
   #   - include: biblio_anchor
   #   - include: indexterm_triple
@@ -588,18 +588,12 @@ contexts:
   # Examples:
   #   {my-attribute}
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # attribute_reference:
-  #   comment: |
-  #     Examples:
-  #       {my-attribute}
-  #   name: variable.other
-  #   match: ({)([A-Za-z0-9_][A-Za-z0-9_-]*)(})
-  #   captures:
-  #     '1': {name: constant.character.attributes.reference.begin.asciidoc}
-  #     '2': {name: support.variable.attribute.asciidoc}
-  #     '3': {name: constant.character.attributes.reference.end.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
+  attribute_reference:
+    - match: ({)([A-Za-z0-9_][A-Za-z0-9_-]*)(})
+      captures:
+       1: constant.character.attributes.reference.begin.asciidoc
+       2: support.variable.attribute.asciidoc
+       3: constant.character.attributes.reference.end.asciidoc
 
   ################
   # BIBLIO ANCHORS
@@ -2100,6 +2094,8 @@ contexts:
 
   lists:
     - include: ulist_item_marker
+    - include: colist_item_marker
+    - include: dlist_item_label
   # lists:
   #   comment: >
   #     My strategy for lists (and similar) is not to try to treat entire
@@ -2107,8 +2103,7 @@ contexts:
   #   - include: block_admonition_label
   #   - include: ulist_item_marker
   #   - include: olist_item_marker
-  #   - include: dlist_item_label
-  #   - include: colist_item_marker
+  #   
 
   ########################
   # ADMONITION BLOCK LABEL
@@ -2185,21 +2180,13 @@ contexts:
   #   <1> a callout
   #   <42> another callout
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # colist_item_marker:
-  #   comment: |
-  #     Marker of a callout list item.
-  #
-  #     Examples:
-  #       <1> a callout
-  #       <42> another callout
-  #   name: markup.list.numbered.callout.asciidoc
-  #   match: ^(\s*((<)\d+?(>)))\s+(?=\S)
-  #   captures:
-  #     '1': {name: string.unquoted.list.callout.asciidoc}
-  #     '2': {name: constant.numeric.callout.asciidoc}
-  #     '3': {name: punctuation.definition.calloutlistnumber.begin.asciidoc}
-  #     '4': {name: punctuation.definition.calloutlistnumber.end.asciidoc}
+  colist_item_marker:
+    - match: ^(\s*((<)\d+?(>)))\s+(?=\S)
+      captures:
+        1: string.unquoted.list.callout.asciidoc
+        2: constant.numeric.callout.asciidoc
+        3: punctuation.definition.calloutlistnumber.begin.asciidoc
+        4: punctuation.definition.calloutlistnumber.end.asciidoc
   # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##################
@@ -2220,34 +2207,11 @@ contexts:
   #     double colon followed by a space inside a label, i.e. it matches the
   #     *last* double colon, not the first. I don't know how to do that
   #     *effectively.
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # dlist_item_label:
-  #   comment: |
-  #     Label of a definition (labeled) list item.
-  #
-  #     Examples:
-  #       Label level 1:: lorem ipsum
-  #       Label level 2::: dolor sit amet
-  #       Label level 3:::: consectetur
-  #       Label level 1::
-  #         lorem ipsum
-  #       Another label :: lorem ipsum
-  #       Last::label:: dolor sit amet
-  #
-  #     Note: This rule is not strictly correct, because Asciidoctor allows
-  #     double colon followed by a space inside a label, i.e. it matches the
-  #     *last* double colon, not the first. I don't know how to do that
-  #     *effectively.
-  #   name: markup.list.labeled.asciidoc
-  #   contentName: meta.list.label.asciidoc
-  #   begin: ^\s*(?=.*:{2,4}(?:\s|$))
-  #   end: (:{2,4})(?:\s|$\n?)
-  #   endCaptures:
-  #     '1': {name: constant.labeledlist.separator.asciidoc}
-  #   - include: inline
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
+  #AR: why isn't this working?
+  dlist_item_label:
+    - match: (.*)(:{2,4})(?:\s|$\n?)
+      captures:
+        1: constant.labeledlist.separator.asciidoc
 
   ###################
   # OLIST ITEM MARKER

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -886,6 +886,7 @@ contexts:
     # - include: mark           # problematic!
     - include: superscript    # problematic!
     - include: subscript
+    - include: attribute_list
 
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -902,6 +903,23 @@ contexts:
   #   - include: superscript
   #   - include: subscript
   # <<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+  ######################
+  # ATTRIBUTE LIST
+  ######################
+  # Emphasized (italic) text (constrained variant).
+  #
+  # Examples:
+  #   [Lorem ipsum] dolor
+  #   [red] Lorem ipsum dolor
+
+  attribute_list:
+    - match: |
+        (?x)
+        (\[[^\]]*?\])?      # might be preceded by an attributes list
+        (?<=^|\W)(?<!\\|})  # must be preceded by nonword character, and not by escape or } (attribute)
+      captures:
+        1: support.variable.attributelist.asciidoc
 
   ######################
   # STRONG UNCONSTRAINED


### PR DESCRIPTION
Added key bindings for bold (ctrl-B), italics (ctrl-I), and typograpical quotes.
Added a pair of snippets for creating and referencing anchors ([[ tab, and << tab)
Added an alternative trigger for the quote block ("" tab).