### PR TITLE
Syntax Baseline

### DIFF
--- a/Examples/Syntax_Demo.adoc
+++ b/Examples/Syntax_Demo.adoc
@@ -1,0 +1,521 @@
+= AsciiDoc Examples That Demonstrate Syntax Highlighting
+
+// This example is heavily based on
+// https://github.com/powerman/asciidoc-cheatsheet/blob/master/full.adoc
+Author Name <author.email@example.com>
+:Revision: 1.0
+:Some-Attribute: Some value
+:toc:
+:toclevels: 1
+
+toc::[]
+
+
+
+== Attributes
+
+Author is "{author}" with email <{email}>,
+some attribute's value is {someattribute}.
+
+// Any line with an unknown attribute is removed.
+Line with attribute like {nosuchattribute}.
+
+Escaped: \{author} and +++{author}+++
+
+
+
+== Headers
+
+== Level 1
+Text.
+
+=== Level 2
+Text.
+
+==== Level 3
+Text.
+
+===== Level 4
+Text.
+
+
+
+IMPORTANT: This syntax definition does not recognize the following old-style headings, and in fact chokes on them:
+
+....
+=Level 1
+-------
+Text.
+
+Level 2
+~~~~~~~
+Text.
+
+Level 3
+^^^^^^^
+Text.
+
+Level 4
++++++++
+Text.
+....
+
+
+
+== Horizontal Rule:
+
+''''
+
+
+
+== Paragraphs
+
+.Optional Title
+Usual
+paragraph.
+
+Second paragraph.
+
+.Optional Title
+ Literal paragraph.
+  Must be indented.
+
+.Optional Title
+[source,perl]
+die 'connect: '.$dbh->errstr;
+
+Not a code in next paragraph.
+
+
+
+== Admonitions
+
+// Type of admonition (NOTE/TIP/…) should be
+// shown as an icon, not as text.
+.Optional Title
+NOTE: This is an example
+      single-paragraph note.
+
+.Optional Title
+[NOTE]
+This is an example
+single-paragraph note.
+
+TIP: Some tip text.
+
+IMPORTANT: Some important text.
+
+WARNING: Some warning text.
+
+CAUTION: Some caution text.
+
+
+
+== Blocks
+
+.Optional Title for Listing Block
+----
+*Listing* Block
+
+Use: code or file listings
+----
+
+.Optional Title for Source Code Block
+[source,perl]
+----
+# *Source* block
+# Use: highlight code listings
+# (require `source-highlight` or `pygmentize`)
+use DBI;
+my $dbh = DBI->connect('...',$u,$p)
+    or die "connect: $dbh->errstr";
+----
+
+.Optional Title for Sidebar Block
+****
+*Sidebar* Block
+
+Use: sidebar notes :)
+****
+
+.Optional Title for Example Block
+==========================
+*Example* Block
+
+Use: examples :)
+==========================
+
+// Example caption removed
+[caption="Custom: "]
+==========================
+Default caption "Example:"
+can be changed.
+==========================
+
+.Optional Title for Example Block Used as Admonition
+[NOTE]
+===============================
+*NOTE* Block
+
+Use: multi-paragraph notes.
+===============================
+
+////
+*Comment* block
+
+Use: hide comments
+////
+
+++++
+*Passthrough* Block
+<p>
+Use: backend-specific markup like
+<table border="1">
+<tr><td>1</td><td>2</td></tr>
+</table>
+++++
+
+.Optional Title for Literal Block
+....
+*Literal* Block
+
+Use: workaround when literal
+paragraph (indented) like
+  1. First.
+  2. Second.
+incorrectly processed as list.
+....
+
+.Optional Title for Quote Block
+[quote, cite author, cite source]
+____
+*Quote* Block
+
+Use: cite somebody
+____
+
+
+
+== Text
+(with "`constrained formatting`")
+
+This paragraph has a forced +
+line break.
+
+normal, _italic_, *bold*, +mono+.
+
+"`double quoted`", '`single quoted`'.
+
+normal, ^super^, ~sub~.
+
+Command: `ls -al`
+
++mono with *bold*+
+
+`passthrough with *bold*`
+
+Path: '/some/filez.txt', '.b'
+
+[red]#red text# [yellow-background]#on yellow#
+[big]#large# [red yellow-background big]*all bold*
+
+
+
+== Characters
+(with "`unconstrained formatting`")
+
+n__i__**b**++m++[red]##r##
+
+(C) (R) (TM) -- ... -> <- => <= &#182;
+
+=== Escaped
+
+\_italic_, +++_italic_+++,
+
++++<b>bold</b>+++, $$<b>normal</b>$$
+
+\&#182;
+
+
+
+== Macros: links, images & include
+
+If you'll need to use space in url/path you should replace it with %20.
+
+[[anchor-1]]
+Paragraph or block 1.
+
+
+<<anchor-1>>,
+<<anchor-1,First anchor>>,
+xref:anchor-2[],
+xref:anchor-2[Second anchor].
+
+
+link:README.adoc[This document]
+link:README.adoc[]
+link:/[This site root]
+
+
+
+http://google.com
+http://google.com[Google Search]
+mailto:root@localhost[email admin]
+
+
+
+First home
+image:images/icons/home.png[]
+, second home
+image:images/icons/home.png[Alt text]
+.
+
+.Block image
+image::images/icons/home.png[]
+image::images/icons/home.png[Alt text]
+
+.Thumbnail linked to full image
+image:/images/font/640-screen2.gif[
+"My screenshot",width=128,
+link="/images/font/640-screen2.gif"]
+
+This is example how files
+can be included.
+
+include::footer.txt[]
+
+[source,perl]
+----
+include::script.pl[]
+----
+
+
+
+== Lists
+
+.Bulleted
+* bullet
+* bullet
+  - bullet
+  - bullet
+* bullet
+** bullet
+** bullet
+*** bullet
+*** bullet
+**** bullet
+**** bullet
+***** bullet
+***** bullet
+**** bullet
+*** bullet
+** bullet
+* bullet
+
+.Bulleted 2
+- bullet
+  * bullet
+
+.Ordered
+. number
+. number
+  .. letter
+  .. letter
+. number
+.. loweralpha
+.. loweralpha
+... lowerroman
+... lowerroman
+.... upperalpha
+.... upperalpha
+..... upperroman
+..... upperroman
+.... upperalpha
+... lowerroman
+.. loweralpha
+. number
+
+.Ordered 2
+a. letter
+b. letter
+   .. letter2
+   .. letter2
+       .  number
+       .  number
+           1. number2
+           2. number2
+           3. number2
+           4. number2
+       .  number
+   .. letter2
+c. letter
+
+.Labeled
+Term 1::
+    Definition 1
+Term 2::
+    Definition 2
+    Term 2.1;;
+        Definition 2.1
+    Term 2.2;;
+        Definition 2.2
+Term 3::
+    Definition 3
+Term 4:: Definition 4
+Term 4.1::: Definition 4.1
+Term 4.2::: Definition 4.2
+Term 4.2.1:::: Definition 4.2.1
+Term 4.2.2:::: Definition 4.2.2
+Term 4.3::: Definition 4.3
+Term 5:: Definition 5
+
+.Labeled 2
+Term 1;;
+    Definition 1
+    Term 1.1::
+        Definition 1.1
+
+[horizontal]
+.Labeled horizontal
+Term 1:: Definition 1
+Term 2:: Definition 2
+[horizontal]
+    Term 2.1;;
+        Definition 2.1
+    Term 2.2;;
+        Definition 2.2
+Term 3::
+    Definition 3
+Term 4:: Definition 4
+[horizontal]
+Term 4.1::: Definition 4.1
+Term 4.2::: Definition 4.2
+[horizontal]
+Term 4.2.1:::: Definition 4.2.1
+Term 4.2.2:::: Definition 4.2.2
+Term 4.3::: Definition 4.3
+Term 5:: Definition 5
+
+[qanda]
+.Q&A
+Question 1::
+    Answer 1
+Question 2:: Answer 2
+
+.Break between two lists
+. number
+. number
+
+Independent paragraph break list.
+
+. number
+
+.Using an Optional Header Starts a New List, Too
+. number
+
+--
+. List block define list boundary too
+. number
+. number
+--
+
+--
+. number
+. number
+--
+
+.Continuation
+- bullet
+continuation
+. number
+  continuation
+* bullet
+
+  literal continuation
+
+.. letter
++
+Non-literal continuation.
++
+----
+any block can be
+
+included in list
+----
++
+Last continuation.
+
+
+
+.Using a List Block Allows a Sublist to be Included
+- bullet
+  * bullet
++
+--
+    - bullet
+      * bullet
+--
+  * bullet
+- bullet
+  . number
+    .. letter
++
+--
+      . number
+        .. letter
+--
+    .. letter
+  . number
+
+
+
+== Tables
+
+You can fill table from CSV file using +include::+ macros inside table.
+
+.An example table
+[options="header,footer"]
+|=======================
+|Col 1|Col 2      |Col 3
+|1    |Item 1     |a
+|2    |Item 2     |b
+|3    |Item 3     |c
+|6    |Three items|d
+|=======================
+
+.CSV data, 15% each column
+[format="csv",width="60%",cols="4"]
+[frame="topbot",grid="none"]
+|======
+1,2,3,4
+a,b,c,d
+A,B,C,D
+|======
+
+[grid="rows",format="csv"]
+[options="header",cols="^,<,<s,<,>m"]
+|===========================
+ID,FName,LName,Address,Phone
+1,Vasya,Pupkin,London,+123
+2,X,Y,"A,B",45678
+|===========================
+
+
+
+.Multiline cells, row/col span
+|====
+|Date |Duration |Avg HR |Notes
+
+|22-Aug-08 .2+^.^|10:24 | 157 |
+Worked out MSHR (max sustainable
+heart rate) by going hard
+for this interval.
+
+|22-Aug-08 | 152 |
+Back-to-back with previous interval.
+
+|24-Aug-08 3+^|none
+
+|====
+
+

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -7,20 +7,6 @@
 # Syntax definition for Asciidoctor:
 # -- https://asciidoctor.org/
 # ------------------------------------------------------------------------------
-# NOTE: This syntax was taken from @bsmith-n4, who slightly improved the
-# original syntax by Asciidoctor. I've annotated all changes by @bsmith-n4 in
-# the source, and included the original, in order to allow comparison.
-#
-# @bsmith-n4 changes include:
-#  -- scope renaming
-#  -- RegEx tweaks
-#  -- new elements
-#  -- element tweaks
-#
-#
-# Ultimately, I'll try to keep the scope names of the original syntax from the
-# Asciidoctor repo, but also keep the improvements by @bsmith-n4, except his own
-# custom elements.
 # ------------------------------------------------------------------------------
 # Copyright (c) Tristano Ajmone, 2019. MIT License.
 # ------------------------------------------------------------------------------
@@ -51,7 +37,7 @@ contexts:
 #*******************************************************************************
 
 # Some definitions whose goal is just capturing some elements to prevent false
-# positives that break the document. Some of this will later on be replaces with
+# positives that break the document. Some of this will later on be replaced with
 # proper capturing elemeents, but for now they are needed to keep the syntax
 # from falling apart...
 
@@ -70,7 +56,6 @@ contexts:
   blocks:
     - include: block_literal
     - include: block_comment
-    # - include: custom_block                           # <- ADDED by @bsmith-n4
     - include: block_listing
     - include: block_source_fenced
     - include: block_sidebar
@@ -101,44 +86,7 @@ contexts:
           pop: true
         # - include: macro
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_comment:
-  #   comment: |
-  #     Examples:
-  #       ////
-  #       A multi-line comment.
-  #       Notice it's a delimited block.
-  #       ////
-  #   name: comment.block.asciidoc
-  #   contentName: meta.block.comment.content.asciidoc
-  #   begin: ^(/{4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: punctuation.definition.comment.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.comment.end.asciidoc}
-  #   - include: macro
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
-  ###############
-  # CUSTOM BLOCKS
-  ###############
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # custom_block:                                       # <- ADDED by @bsmith-n4
-  #   name: markup.underline.block.id.def.asciidoc
-  #   match: |
-  #     (?x)^
-  #     (\[)
-  #     (sect\d|def|math|TODO|quote|example|source,?(\w+))
-  #     (\s*\])
-  #     \s*$\n?
-  #   captures:
-  #     '1': {name: markup.underline.block.asciidoc}
-  #     '2': {name: markup.underline.block.asciidoc}
-  #     '3': {name: variable.parameter.sourcelang.asciidoc}
-  #     '4': {name: markup.underline.block.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #################
   # EXAMPLE BLOCKS
@@ -159,42 +107,21 @@ contexts:
           pop: true
         - include: lists
         # - include: block_listing
-        - include: blocks
+        - include: blocks   # FIXME Is this supposed to be here? It's not in the original, and it looks like a circular reference.
         - include: lines
         - include: inline
         - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_example:
-  #   comment: |
-  #     Examples:
-  #       ====
-  #       Lorem ipsum.
-  #       ====
+  #     Note: Might need to add more includes.
   #
-  #     Note: Might need to add more includes, but these are the ones that arise in
-  #     practice for me.
-  #   name: string.unquoted.block.example.asciidoc
-  #   contentName: meta.block.example.content.asciidoc
-  #   begin: ^(={4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: constant.delimiter.example.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: constant.delimiter.example.end.asciidoc}
-  #   - include: lists
-  #   - include: block_listing
-  #   - include: lines
-  #   - include: inline
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ################
   # LISTING BLOCKS
   ################
   # Examples:
+  #   [source,python]
   #   ----
-  #   Lorem ipsum.
+  #   print "Lorem ipsum."
   #   ----
 
   block_listing:
@@ -208,30 +135,7 @@ contexts:
           pop: true
   #   - include: inline_callout
 
-  # IMPORTANT: This element was REMANED by @bsmith-n4! In the original:
-  #
-  #     '0': {name: constant.delimiter.listing.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: constant.delimiter.listing.end.asciidoc}
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_listing:
-  #   comment: |
-  #     Examples:
-  #       ----
-  #       Lorem ipsum.
-  #       ----
-  #   name: meta.embedded.block.listing.asciidoc
-  #   contentName: source.block.listing.content.asciidoc
-  #   begin: ^(\-{4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: markup.underline.listing.begin.asciidoc}  # <- RENAMED by @bsmith-n4
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: markup.underline.listing.end.asciidoc}    # <- RENAMED by @bsmith-n4
-  #   - include: inline_callout
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ######################
   # FENCED SOURCE BLOCKS
@@ -258,39 +162,11 @@ contexts:
           pop: true
         # - include: inline_callout
 
-    # name: meta.embedded.block.listing.asciidoc
-    # contentName: source.block.listing.content.asciidoc
-    # begin: ^(```)(\w+)?\s*$\n?
-    # beginCaptures:
-    #   '0': {name: constant.delimiter.listing.begin.asciidoc}
-    # end: ^\1\s*$\n?
-    # endCaptures:
-    #   '0': {name: constant.delimiter.listing.end.asciidoc}
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_source_fenced:
-  #   comment: |
-  #     Fenced code block (ala Markdown)
-  #
-  #     Examples:
-  #       ```rb
-  #       puts 'Hello world!'
-  #       ```
-  #   name: meta.embedded.block.listing.asciidoc
-  #   contentName: source.block.listing.content.asciidoc
-  #   begin: ^(```)(\w+)?\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: constant.delimiter.listing.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: constant.delimiter.listing.end.asciidoc}
-  #   - include: inline_callout
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ################
   # LITERAL BLOCKS
   ################
-  # Examples:
+  # Examples: (must be four or more dots, since three dots is an ellipses)
   #   ....
   #   Lorem ipsum.
   #   ....
@@ -306,23 +182,6 @@ contexts:
         # - match: ^.*$\n?
         #   scope: meta.block.literal.content.asciidoc
         # - include: inline_callout
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_literal:
-  #   comment: |
-  #     Examples:
-  #       ....
-  #       Lorem ipsum.
-  #       ....
-  #   name: string.literal.block.delimited.asciidoc
-  #   contentName: meta.block.literal.content.asciidoc
-  #   begin: ^(\.{4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: constant.delimiter.block.literal.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: constant.delimiter.block.literal.end.asciidoc}
-  #   - include: inline_callout
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #############
   # OPEN BLOCKS
@@ -350,37 +209,7 @@ contexts:
         - include: inline
         - include: characters
 
-  # IMPORTANT: This element was REMANED by @bsmith-n4! In the original:
-  #
-  #    '0': {name: constant.delimiter.block.open.begin.asciidoc}
-  #  end: ^\-\-\s*$\n?
-  #  endCaptures:
-  #    '0': {name: constant.delimiter.block.open.end.asciidoc}
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_open:
-  #   comment: |
-  #     Examples:
-  #       --
-  #       Lorem ipsum
-  #       --
-  #     Note: Might need to check on these includes.
-  #   name: meta.block.open.asciidoc
-  #   contentName: meta.block.open.content.asciidoc
-  #   begin: ^\-\-\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: markup.underline.block.open.begin.asciidoc}  # <- RENAMED by @bsmith-n4
-  #   end: ^\-\-\s*$\n?
-  #   endCaptures:
-  #     '0': {name: markup.underline.block.open.begin.asciidoc}  # <- RENAMED by @bsmith-n4
-  #   - include: lists
-  #   - include: block_comment
-  #   - include: block_listing
-  #   - include: block_pass
-  #   - include: lines
-  #   - include: inline
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #############
   # PASS BLOCKS
@@ -397,25 +226,6 @@ contexts:
           pop: true
       # - include: text.xml
 
-  # IMPORTANT: This element was REMANED by @bsmith-n4! In the original:
-  #
-  #   '0': {name: constant.delimiter.block.passthrough.begin.asciidoc}
-  # end: ^\1\s*$\n?
-  # endCaptures:
-  #   '0': {name: constant.delimiter.block.passthrough.end.asciidoc}
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_pass:
-  #   name: meta.embedded.block.passthrough.asciidoc
-  #   contentName: text.xml.block.passthrough.content.asciidoc
-  #   begin: ^(\+{4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: markup.underline.block.passthrough.begin.asciidoc}  # <- RENAMED by @bsmith-n4
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: markup.underline.block.passthrough.end.asciidoc}    # <- RENAMED by @bsmith-n4
-  #   - include: text.xml
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##############
   # QUOTE BLOCKS
@@ -437,38 +247,8 @@ contexts:
         - include: lines
         - include: inline
         - include: characters
+        #  Note: Might need to add more includes.
 
-    # name: markup.quote.block.asciidoc
-    # contentName: meta.block.quote.content.asciidoc
-    # begin: ^(_{4,})\s*$\n?
-    # beginCaptures:
-    #   '0': {name: constant.delimiter.block.quote.begin.asciidoc}
-    # end: ^\1\s*$\n?
-    # endCaptures:
-    #   '0': {name: constant.delimiter.block.quote.end.asciidoc}
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_quote:
-  #   comment: >
-  #     Examples:
-  #       ____
-  #       Lorem ipsum
-  #       ____
-  #
-  #     Note: Might need to add more includes, but these are the ones that arise
-  #     for me in practice.
-  #   name: markup.quote.block.asciidoc
-  #   contentName: meta.block.quote.content.asciidoc
-  #   begin: ^(_{4,})\s*$\n?
-  #   beginCaptures:
-  #     '0': {name: constant.delimiter.block.quote.begin.asciidoc}
-  #   end: ^\1\s*$\n?
-  #   endCaptures:
-  #     '0': {name: constant.delimiter.block.quote.end.asciidoc}
-  #   - include: lines
-  #   - include: inline
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #################
   # SIDEBAR BLOCKS
@@ -493,15 +273,8 @@ contexts:
         - include: lines
         - include: inline
         - include: characters
+        #  Note: Might need to add more includes.
 
-    # name: string.quoted.block.sidebar.asciidoc
-    # contentName: meta.block.sidebar.content.asciidoc
-    # begin: ^(\*{4,})\s*$\n?
-    # beginCaptures:
-    #   '0': {name: constant.delimiter.block.sidebar.begin.asciidoc}
-    # end: ^\1\s*$\n?
-    # endCaptures:
-    #   '0': {name: constant.delimiter.block.sidebar.end.asciidoc}
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>
   # block_sidebar:
@@ -645,10 +418,8 @@ contexts:
   #########
   # ESCAPES
   #########
-  # List of special characters that may be escaped.
-
-  # @NOTE (IN ORIGINAL): I do not really know if this is a good list, adopted
-  #                      wholesale from original bundle.
+  # In AsciiDoc, certain characters need to be escaped with a backslash.
+  # TODO This might not be a complete list of characters need to be escaped.
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>
   # escape:
@@ -667,6 +438,7 @@ contexts:
   # Double parenthesis indexterm.
   # Examples:
   #   ((Arthur))
+  #   (("Doyle, Arthur Conan"))
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>
   # indexterm_double:
@@ -888,20 +660,6 @@ contexts:
     - include: subscript
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # inline:
-  #   - include: passthrough
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ######################
   # STRONG UNCONSTRAINED
@@ -984,8 +742,8 @@ contexts:
   # Was: "STRONG"
   # Strong (bold) text (unconstrained variant).
   # Examples:
-  #   Lo**re**m **ipsum dolor**.
-  #   Lo[red]**re**m
+  #   *Lorem ipsum* dolor
+  #   [red]*Lorem ipsum* dolor
   strong:
     - match: |
         (?x)
@@ -1022,40 +780,6 @@ contexts:
       #   - include: subscript
       #   - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # strong:
-  #   comment: |
-  #     Strong (bold) text (constrained variant).
-  #
-  #     Examples:
-  #       *Lorem ipsum* dolor
-  #       [red]*Lorem ipsum* dolor
-  #   name: markup.bold.single.asciidoc
-  #   contentName: meta.boldinner.single.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?      # might start with an attributes list
-  #     (?<=^|\W)(?<!\\|})  # must be preceded by nonword character, and not by escape or } (attribute)
-  #     (\*)(?=\S)          # delimiter star that must be followed by a nonspace character
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.bold.single.begin.asciidoc}
-  #   end: |-
-  #     (?x)
-  #     (?<=\S)(\*)       # delimiter star that must be preceded by a nonspace character
-  #     (?!\w)            # ...and followed by a nonword character
-  #   endCaptures:
-  #     '1': {name: punctuation.definition.bold.single.end.asciidoc}
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
   ########################
@@ -1101,37 +825,6 @@ contexts:
     #   - include: characters
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # emphasis_double:
-  #   comment: |
-  #     Emphasized (italic) text (unconstrained variant).
-  #
-  #     Examples:
-  #       Lo__re__m __ipsum dolor__.
-  #       Lo[red]__re__m
-  #   name: markup.italic.double.asciidoc
-  #   contentName: meta.italicinner.double.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?  # might start with attribute list
-  #     (?<!\\)         # must not be preceded by escape
-  #     (__)
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.italic.double.begin.asciidoc}
-  #   end: '__'
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.italic.double.end.asciidoc}
-  #   - include: strong_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ######################
   # EMPHASIS CONSTRAINED
@@ -1179,41 +872,6 @@ contexts:
     # - include: subscript
     # - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # emphasis:
-  #   comment: |
-  #     Emphasized (italic) text (constrained variant).
-  #
-  #     Examples:
-  #       _Lorem ipsum_ dolor
-  #       [red]_Lorem ipsum_ dolor
-  #   name: markup.italic.single.asciidoc
-  #   contentName: meta.italicinner.single.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?      # might be preceded by an attributes list
-  #     (?<=^|\W)(?<!\\|})  # must be preceded by nonword character, and not by escape or } (attribute)
-  #     (_)(?=\S)           # delimiter underscore that must be followed by a nonspace character
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.italic.single.begin.asciidoc}
-  #   end: |-
-  #     (?x)
-  #     (?<=\S)(_)        # delimiter underscore that must be preceded by a nonspace character
-  #     (?!\w)            # ...and followed by a nonword character
-  #   endCaptures:
-  #     '1': {name: punctuation.definition.italic.single.end.asciidoc}
-  #   - include: strong_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
 
 
   ##########################
@@ -1256,37 +914,6 @@ contexts:
     # - include: subscript
     # - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # monospaced_double:
-  #   comment: |
-  #     Monospaced text (unconstrained variant).
-  #
-  #     Examples:
-  #       Lo``re``m ``ipsum dolor``.
-  #       Lo[red]``re``m
-  #   name: string.other.literal.double.asciidoc
-  #   contentName: meta.literalinner.double.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?  # might start with attribute list
-  #     (?<!\\)         # must not be preceded by escape
-  #     (``)
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.literal.double.begin.asciidoc}
-  #   end: '``'
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.literal.double.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
   ########################
@@ -1343,47 +970,13 @@ contexts:
   #   - include: characters
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # monospaced:
-  #   comment: |
-  #     Monospaced text (constrained variant).
-  #
-  #     Examples:
-  #       `Lorem ipsum` dolor
-  #       [red]`Lorem ipsum` dolor
-  #   name: string.other.literal.single.asciidoc
-  #   contentName: meta.literalinner.single.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?      # might start with attributes list
-  #     (?<=^|\W)(?<!\\|})  # must be preceded by nonword character, and not by escape or } (attribute)
-  #     (`)(?=\S)           # delimiter backtick that must be followed by a nonspace character
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.literal.single.begin.asciidoc}
-  #   end: |-
-  #     (?x)
-  #     (?<=\S)(`)        # delimiter backtick that must be preceded by a nonspace character
-  #     (?!\w)            # ...and followed by a nonword character
-  #   endCaptures:
-  #     '1': {name: punctuation.definition.literal.single.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: mark
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
 
   #############
   # PASSTHROUGH
   #############
-  # Inline triple-plus and double dolar passthrough.
+  # Inline triple-plus and double dollar passthrough.
   # Examples:
   #   Lo+++re++++m +++ipsum dolor+++.
   #   Lo$$re$$m $$ipsum dolor$$.
@@ -1400,25 +993,6 @@ contexts:
           scope: constant.character.passthru.end.asciidoc
           pop: true
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # passthrough:
-  #   comment: |
-  #     Inline triple-plus and double dolar passthrough.
-  #
-  #     Examples:
-  #       Lo+++re++++m +++ipsum dolor+++.
-  #       Lo$$re$$m $$ipsum dolor$$.
-  #
-  #     Note: Must be dead first among the inlines, so as to take priority.
-  #   name: meta.passthru.inline.asciidoc
-  #   contentName: variable.parameter.passthruinner.asciidoc
-  #   begin: (\+\+\+|\$\$)
-  #   beginCaptures:
-  #     '1': {name: constant.character.passthru.begin.asciidoc}
-  #   end: '\1'
-  #   endCaptures:
-  #     '0': {name: constant.character.passthru.end.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
   ####################
@@ -1455,51 +1029,7 @@ contexts:
         #   - include: subscript
         #   - include: characters
 
-    # name: string.other.unquoted.double.asciidoc
-    # contentName: string.unquoted.unquotedinner.double.asciidoc
-    # begin: |-
-    #   (?x)
-    #   (\[[^\]]*?\])?  # might start with an attribute list (indeed, that is its purpose)
-    #   (?<!\\)         # must not be preceded by escape
-    #   (\#\#)
-    # beginCaptures:
-    #   '1': {name: support.variable.attributelist.asciidoc}
-    #   '2': {name: punctuation.definition.string.unquoted.double.begin.asciidoc}
-    # end: '\#\#'
-    # endCaptures:
-    #   '0': {name: punctuation.definition.string.unquoted.double.end.asciidoc}
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # mark_double:
-  #   comment: |
-  #     Marked text (unconstrained variant).
-  #
-  #     Examples:
-  #       Lo##re##m ##ipsum dolor##.
-  #       Lo[red]##re##m
-  #   name: string.other.unquoted.double.asciidoc
-  #   contentName: string.unquoted.unquotedinner.double.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?  # might start with an attribute list (indeed, that is its purpose)
-  #     (?<!\\)         # must not be preceded by escape
-  #     (\#\#)
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.string.unquoted.double.begin.asciidoc}
-  #   end: '\#\#'
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.string.unquoted.double.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##################
   # MARK CONSTRAINED
@@ -1510,8 +1040,8 @@ contexts:
   #   #Lorem ipsum# dolor
   #   [red]#Lorem ipsum# dolor
 
-  # @PROBLEM: Braks everything! seems like optional "start with attribute"
-  #           causes anything to matche anything else!
+  # @PROBLEM: Breaks everything! seems like optional "start with attribute"
+  #           causes anything to match anything else!
 #  mark:
 #    - match: |
 #        (?x)
@@ -1540,48 +1070,14 @@ contexts:
 #        # - include: subscript
 #        # - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # mark:
-  #   comment: |
-  #     Marked text (constrained variant).
-  #
-  #     Examples:
-  #       #Lorem ipsum# dolor
-  #       [red]#Lorem ipsum# dolor
-  #   name: string.other.unquoted.single.asciidoc
-  #   contentName: string.unquoted.unquotedinner.single.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?      # might start with attribute list (darned well better or why are we here)
-  #     (?<=^|\W)(?<!\\|})  # must be preceded by nonword character, and not by escape or } (attribute)
-  #     (\#)(?=\S)          # delimiter hash that must be followed by a nonspace character
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.string.unquoted.single.begin.asciidoc}
-  #   end: |-
-  #     (?x)
-  #     (?<=\S)(\#)       # delimiter hash that must be preceded by a nonspace character
-  #     (?!\w)            # ...and followed by a nonword character
-  #   endCaptures:
-  #     '1': {name: punctuation.definition.string.unquoted.single.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: superscript
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ###########
   # SUBSCRIPT
   ###########
   # Subscript text.
   # Examples:
-  #   E=mc^2^
-  #   E=mc[red]^2^
+  #   H~2~O
+  #   H[red]~2~O
 
   subscript:
     - match: |
@@ -1610,46 +1106,14 @@ contexts:
       #   - include: characters
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # subscript:
-  #   comment: |
-  #     Subscript text.
-  #
-  #     Examples:
-  #       E=mc^2^
-  #       E=mc[red]^2^
-  #   name: string.other.subscript.asciidoc
-  #   contentName: meta.subscriptinner.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?  # might start with attribute list
-  #     (?<!\\)         # must not be preceded by escape
-  #     (~)
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.string.subscript.begin.asciidoc}
-  #   end: '~'
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.string.subscript.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: superscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #############
   # SUPERSCRIPT
   #############
   # Superscript text.
   # Examples:
-  #   H~2~O
-  #   H[red]~2~O
+  #   E=mc^2^
+  #   E=mc[red]^2^
 
   superscript:
     - match: |
@@ -1678,38 +1142,6 @@ contexts:
       #   - include: characters
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # superscript:
-  #   comment: |
-  #     Superscript text.
-  #
-  #     Examples:
-  #       H~2~O
-  #       H[red]~2~O
-  #   name: string.other.superscript.asciidoc
-  #   contentName: meta.superscriptinner.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     (\[[^\]]*?\])?  # might start with attribute list
-  #     (?<!\\)         # no preceding escape
-  #     (\^)
-  #   beginCaptures:
-  #     '1': {name: support.variable.attributelist.asciidoc}
-  #     '2': {name: punctuation.definition.string.superscript.begin.asciidoc}
-  #   end: '^'
-  #   endCaptures:
-  #     '0': {name: punctuation.definition.string.superscript.end.asciidoc}
-  #   - include: strong_double
-  #   - include: emphasis_double
-  #   - include: monospaced_double
-  #   - include: mark_double
-  #   - include: strong
-  #   - include: emphasis
-  #   - include: monospaced
-  #   - include: mark
-  #   - include: subscript
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 #*******************************************************************************
 #                                                                              *
@@ -1788,34 +1220,6 @@ contexts:
           pop: true
         #   - include: characters
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # attribute_entry:
-  #   comment: |
-  #     An attribute entry.
-  #
-  #     Examples:
-  #       :my-attribute: value
-  #       :sectnums!:
-  #       :!sectnums:
-  #   name: meta.attributeentry.asciidoc
-  #   contentName: meta.attributeentry.value.asciidoc
-  #   begin: |-
-  #     (?x)
-  #     ^(:)                          # opening delimiter
-  #     (!)?                          # bang symbol (unset attribute)
-  #     ([A-Za-z0-9_][A-Za-z0-9_-]*)  # attribute name
-  #     (!)?                          # bang symbol (unset attribute)
-  #     (:)                           # closing delimiter
-  #     (?:\s+|(?=$))
-  #   beginCaptures:
-  #     '1': {name: punctuation.definition.attributeentry.attrname.begin.asciidoc}
-  #     '2': {name: punctuation.definition.attributeentry.unset.asciidoc}
-  #     '3': {name: support.variable.attribute.asciidoc}
-  #     '4': {name: punctuation.definition.attributeentry.unset.asciidoc}
-  #     '5': {name: punctuation.definition.attributeentry.attrname.end.asciidoc}
-  #   end: $\n?
-  #   - include: characters
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   #####################
   # ATTRIBUTE LIST LINE
@@ -1840,14 +1244,11 @@ contexts:
   #############
   # BLOCK TITLE
   #############
-  # Title of a block. Exludes custom block titles for better
+  # Title of a block. Excludes custom block titles for better
   # scoping / preventing overlap.
   # Examples:
   #   .My title
   #   Lorem ipsum dolor.
-
-  # IMPORTANT: This element differs in @bsmith-n4 and original!
-  #            @bsmith-n4 doesn't scope the dot.
 
   block_title:
     - match: ^(\.)(\w.*)$\n?
@@ -1855,32 +1256,6 @@ contexts:
         1: punctuation.definition.blockheading.asciidoc
         2: markup.heading.block.asciidoc
 
-  # >>>>>>>> bsmith-n4 >>>>>>>>
-  # block_title:
-  #   comment: |
-  #     Title of a block. Exludes custom block titles for better
-  #     scoping / preventing overlap.
-  #
-  #     Examples:
-  #       .My title
-  #       Lorem ipsum dolor.
-  #   name: markup.heading.block.asciidoc
-  #   match: ^(\.)\w.*$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>> Asciidoctor >>>>>>>
-  # block_title:
-  #   comment: |
-  #     Title of a block.
-  #
-  #     Examples:
-  #       .My title
-  #       Lorem ipsum dolor.
-  #   name: markup.heading.block.asciidoc
-  #   match: ^(\.)\w.*$\n?
-  #   captures:
-  #     '1': {name: punctuation.definition.blockheading.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##########
   # BLOCK ID
@@ -1898,21 +1273,6 @@ contexts:
         2: markup.underline.blockid.id.asciidoc
         3: punctuation.definition.blockid.end.asciidoc
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_id:
-  #   comment: |
-  #     A block id (i.e. anchor).
-  #
-  #     Examples:
-  #       [[myid]]
-  #       Lorem ipsum dolor.
-  #   name: meta.tag.blockid.asciidoc
-  #   match: ^(\[\[)([^\[].*)(\]\])\s*$\n?
-  #   captures:
-  #     '1': {name: punctuation.definition.blockid.begin.asciidoc}
-  #     '2': {name: markup.underline.blockid.id.asciidoc}
-  #     '3': {name: punctuation.definition.blockid.end.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ###########
   # BLOCK REQ
@@ -1955,17 +1315,6 @@ contexts:
       scope: constant.linebreak.asciidoc
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # inline_break:
-  #   comment: |
-  #     Line hard break with a plus sign (+).
-  #
-  #     Examples:
-  #       Rubies are red, +
-  #       Topazes are blue.
-  #   name: constant.linebreak.asciidoc
-  #   match: (?<=\s)\+$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ###################
   # LIST CONTINUATION
@@ -1982,11 +1331,6 @@ contexts:
     - match: ^\+\s*$\n?
       scope: constant.listcontinuation.asciidoc
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # list_continuation:
-  #   name: constant.listcontinuation.asciidoc
-  #   match: ^\+\s*$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##################
   # BLOCK PAGE BREAK
@@ -2001,18 +1345,6 @@ contexts:
       scope: meta.separator.pagebreak.asciidoc
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_page_break:
-  #   comment: |
-  #     A page break.
-  #
-  #     Examples:
-  #       <<<
-  #       <<<<<
-  #   name: meta.separator.pagebreak.asciidoc
-  #   match: ^<{3,}$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
   ######################
   # BLOCK THEMATIC BREAK
   ######################
@@ -2026,17 +1358,6 @@ contexts:
       scope: meta.separator.ruler.asciidoc
 
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # block_thematic_break:
-  #   comment: |
-  #     A thematic break (aka horizontal rule).
-  #
-  #     Examples:
-  #       '''
-  #       ''''''
-  #   name: meta.separator.ruler.asciidoc
-  #   match: ^'{3,}$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ##################
   # SECTION TEMPLATE
@@ -2079,13 +1400,11 @@ contexts:
 #                                  L I S T S                                   *
 #                                                                              *
 #*******************************************************************************
+# NOTE: For lists (and similar), we don't to try to match on the entire
+#       paragraph, just the opening syntax.
 
   lists:
     - include: ulist_item_marker
-  # lists:
-  #   comment: >
-  #     My strategy for lists (and similar) is not to try to treat entire
-  #     paragraphs as lists, but only call out the opening.
   #   - include: block_admonition_label
   #   - include: ulist_item_marker
   #   - include: olist_item_marker
@@ -2136,28 +1455,6 @@ contexts:
 
       # scope: markup.list.bulleted.asciidoc
 
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # ulist_item_marker:
-  #   comment: |
-  #     Marker of an unordered (bullet) list item.
-  #
-  #     Examples:
-  #       * level 1
-  #       ** level 2
-  #       *** level 3
-  #       **** level 4
-  #       ***** level 5
-  #       - level 1
-  #       -- level 2
-  #       --- level 3
-  #       ---- level 4
-  #       ----- level 5
-  #   name: markup.list.bulleted.asciidoc
-  #   match: ^(\s*(\-|\*{1,5}))\s+(?=\S)
-  #   captures:
-  #     '1': {name: string.unquoted.list.bullet.asciidoc}
-  #     '2': {name: constant.numeric.list.bullet.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   ####################
   # COLIST ITEM MARKER
@@ -2280,6 +1577,9 @@ contexts:
 #       == Level 1 Section
 #
 #       === Level 2 Section
+#
+# FIXME Do "markup.heading.level.1.asciidoc" etc. really need "level"? I think "markup.heading.1.asciidoc" should suffice, plus it's what I've seen color schemes expect. -- polyglot-jones
+# FIXME How about changing "markup.heading.level.0.asciidoc" "markup.title.asciidoc"? -- polyglot-jones
 
   section_titles:
     - include: title_level_5
@@ -2296,19 +1596,6 @@ contexts:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
-  # >>>>>>> Asciidoctor >>>>>>>
-  # match: ^(=) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_0:
-  #   name: markup.heading.level.0.asciidoc
-  #   match: ^(=) (`?\w.*)$\n?                        # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
   title_level_1:
     - match: ^(==) (`?\w.*)$\n?
       scope: markup.heading.level.1.asciidoc
@@ -2316,18 +1603,6 @@ contexts:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
-  # >>>>>>> Asciidoctor >>>>>>>
-  #   match: ^(==) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_1:
-  #   name: markup.heading.level.1.asciidoc
-  #   match: ^(==) (`?\w.*)$\n?                       # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   title_level_2:
     - match: ^(===) (`?\w.*)$\n?
@@ -2336,18 +1611,6 @@ contexts:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
-  # >>>>>>> Asciidoctor >>>>>>>
-  #   match: ^(===) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_2:
-  #   name: markup.heading.level.2.asciidoc
-  #   match: ^(===) (`?\w.*)$\n?                      # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   title_level_3:
     - match: ^(====) (`?\w.*)$\n?
@@ -2356,38 +1619,12 @@ contexts:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
-  # >>>>>>> Asciidoctor >>>>>>>
-  #   match: ^(====) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_3:
-  #   name: markup.heading.level.3.asciidoc
-  #   match: ^(====) (`?\w.*)$\n?                     # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
   title_level_4:
     - match: ^(=====) (`?\w.*)$\n?
       scope: markup.heading.level.4.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
-
-  # >>>>>>> Asciidoctor >>>>>>>
-  #   match: ^(=====) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_4:
-  #   name: markup.heading.level.4.asciidoc
-  #   match: ^(=====) (`?\w.*)$\n?                    # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   title_level_5:
     - match: ^(======) (`?\w.*)$\n
@@ -2396,25 +1633,13 @@ contexts:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
-  # >>>>>>> Asciidoctor >>>>>>>
-  #   match: ^(======) (\w.*)$\n?
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-  # >>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # title_level_5:
-  #   name: markup.heading.level.5.asciidoc
-  #   match: ^(======) (`?\w.*)$\n?                   # <- TWEAKED by @bsmith-n4
-  #   captures:
-  #     '1': {name: punctuation.definition.heading.asciidoc}
-  #     '2': {name: entity.name.section.asciidoc}
-  # <<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 #*******************************************************************************
 #                                                                              *
 #                              R E U S A B L E S                               *
 #                                                                              *
 #*******************************************************************************
-# Resuable contexts...
+# Reusable contexts...
 
   #####################
   # ERROR ON EMPTY LINE


### PR DESCRIPTION
Asciidoctor.sublime-syntax -- Comments Only:

- Fixed typos.
- Removed old, commented-out code.
- Removed mentions of a custom block.
- Improved/corrected many of the cited examples.
- Changed all "Passthru" to "Passthrough", for consistency.

Added Examples/Syntax_Demo.adoc -- All is okay until we get to the table at the end with the known issue of carets that get misinterpreted.